### PR TITLE
Export Node Coordinates of Selected Element

### DIFF
--- a/UserInterface/SourceCode/ElementBasicDisplay.cpp
+++ b/UserInterface/SourceCode/ElementBasicDisplay.cpp
@@ -20,68 +20,54 @@ int getInfoBoxIndex(int node_number, NodeInfoHeader header)
     return ((int)header) * n_nodes_per_element + node_number;
 }
 
-ElementBasicDisplay::ElementBasicDisplay(QWidget *parent) : QGridLayout(parent)
+ElementBasicDisplay::ElementBasicDisplay()
 {
-    // add the "selected item properties" panel header to the grid
-    // this will be the top-level parent of the QWidgets in this layout,
-    // and answers to the parent of this layout
-    selection_header = new Header(panel_header_text, parent);
+    // add the "selected item properties" label to the grid
     addWidget(selection_header, 0, 0, 1, 2, AL_LEFT);
 
-    // add the element selection box
-    element_selection_box = new SelectionBox(selection_header);
-    addWidget(element_selection_box, 1, 4, 1, 1, AL_LEFT);
-    // add the element selection box's label
-    element_selection_label = new Label("Select <br> element", element_selection_box);
-    addWidget(element_selection_label, 0, 4, 1, 1, AL_LEFT);
-
-    // add node selection box
-    node_selection_box = new SelectionBox(selection_header);
-    addWidget(node_selection_box, 1, 3, 1, 1, AL_LEFT);
-    // add node selection box label
-    node_selection_label = new Label("Select <br> node:", node_selection_box);
-    addWidget(node_selection_label, 0, 3, 1, 1, AL_LEFT);
-
     // add the "element name" label to the grid
-    element_name_label = new Header(element_name_label_text, selection_header);
     addWidget(element_name_label, 1, 0, 1, 1, AL_LEFT);
+
     // add the "element name" box to the grid next to the label
-    element_name_display = new ReadOnlyBox("No element selected", element_name_label);
     addWidget(element_name_display, 1, 1, 1, 2, AL_LEFT);
 
     // add the node information headers (horz) into the grid
     for (int i=0; i<n_node_info_headers; i++) {
-        node_info_labels_horz[i] = new Header(horz_info_label_text[i], selection_header);
         addWidget(node_info_labels_horz[i], 2, i+1, 1, 1, AL_CENTRE);
     }
 
     // add the node information node numbers (vert) to the grid
     for (int i=0; i<n_nodes_per_element; i++) {
-        node_info_numbers_vert[i] = new Header(vert_node_label_text + QString::number(i, 'f', 0), selection_header);
         addWidget(node_info_numbers_vert[i], 2+(i+1), 0, 1, 1, AL_LEFT);
     }
 
     // add the node information ID and coordinate boxes
     for (int i=0; i<n_coord_boxes; i++) {
-        node_coord_boxes[i] = new ReadOnlyBox(selection_header);
-        node_coord_boxes[i]->setFixedWidth(node_coord_box_width);
+        node_coord_boxes[i].setFixedWidth(node_coord_box_width);
         // get the row and column indices in the grid for this box
         int row = 0; NodeInfoHeader col = NodeInfoHeader::ID;
         rowAndColOfBox(i, &row, &col);
         // add the widget to the grid
         // offset (row, col) by (3,1) to account for the selection boxes above,
-        // and the node # labels to the left
-        addWidget(node_coord_boxes[i], row+3, col+1, 1, 1, AL_LEFT);
+        // and the node #x labels to the left
+        addWidget(&node_coord_boxes[i], row+3, col+1, 1, 1, AL_LEFT);
     }
+
+    // add node and element display labels to the grid
+    addWidget(node_selection_label, 0, 3, 1, 1, AL_LEFT);
+    addWidget(element_selection_label, 0, 4, 1, 1, AL_LEFT);
+    // now add the corresponding boxes
+    addWidget(&node_selection_box, 1, 3, 1, 1, AL_LEFT);
+    addWidget(&element_selection_box, 1, 4, 1, 1, AL_LEFT);
 };
 
 void ElementBasicDisplay::setNodeSelectionValidator(int max_node_index, QObject *parent)
 {
-    node_selection_box->initialseValidator(max_node_index, parent);
+    node_selection_box.initialseValidator(max_node_index, parent);
 };
 void ElementBasicDisplay::setElementSelectionValidator(int max_element_index, QObject *parent)
 {
-    element_selection_box->initialseValidator(max_element_index, parent);
+    element_selection_box.initialseValidator(max_element_index, parent);
 };
 void ElementBasicDisplay::setDisplayedElementName(const QString &text) {
     element_name_display->setText(text);
@@ -89,8 +75,8 @@ void ElementBasicDisplay::setDisplayedElementName(const QString &text) {
 
 void ElementBasicDisplay::updateCoordBox(int box_number, QString text, bool set_enabled)
 {
-    node_coord_boxes[box_number]->setText(text);
-    node_coord_boxes[box_number]->setEnabled(set_enabled);
+    node_coord_boxes[box_number].setText(text);
+    node_coord_boxes[box_number].setEnabled(set_enabled);
 }
 void ElementBasicDisplay::updateCoordBox(int row, NodeInfoHeader col, QString text, bool set_enabled)
 {
@@ -132,7 +118,6 @@ void ElementBasicDisplay::updateDisplayValues(std::unique_ptr<ShapeBase> *elemen
         }
     }
 }
-
 void ElementBasicDisplay::writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element) {
     // open the file, in append mode if necessary (might have asked for node positions to be written)
     ofstream file(filename.toStdString(), std::ios_base::app);
@@ -164,24 +149,4 @@ void ElementBasicDisplay::writeNodePositions(QString filename, std::unique_ptr<S
     }
     // close file now that we're done with it
     file.close();
-}
-
-void ElementBasicDisplay::resetElementSelection(int max_element_index, QWidget *parent) {
-    // block signals whilst resetting
-    element_selection_box->blockSignals(true);
-    // reset the text in the selection box
-    setElementSelectionValidator(max_element_index, parent);
-    element_selection_box->setText("");
-    // reopen to user input
-    element_selection_box->blockSignals(false);
-}
-
-void ElementBasicDisplay::resetNodeSelection(int max_node_index, QWidget *parent) {
-    // block signals whilst resetting
-    node_selection_box->blockSignals(true);
-    // reset the text in the selection box
-    setNodeSelectionValidator(max_node_index, parent);
-    node_selection_box->setText("");
-    // reopen to user input
-    node_selection_box->blockSignals(false);
 }

--- a/UserInterface/SourceCode/ElementBasicDisplay.cpp
+++ b/UserInterface/SourceCode/ElementBasicDisplay.cpp
@@ -118,3 +118,35 @@ void ElementBasicDisplay::updateDisplayValues(std::unique_ptr<ShapeBase> *elemen
         }
     }
 }
+void ElementBasicDisplay::writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element) {
+    // open the file, in append mode if necessary (might have asked for node positions to be written)
+    ofstream file(filename.toStdString(), std::ios_base::app);
+    file << "====== Node Information (id, x, y, z) =====\n";
+
+    // now we just need to write the positions of the elements to the currently selected node
+    // if we have not been passed a nullptr, we can safely update the information
+    if (element) {
+        // write the information to the infoboxes
+        for (int row = 0; row < n_nodes_per_element; row++) {
+            // these are the box indices for this row
+            int box_id_ind = getInfoBoxIndex(row, NodeInfoHeader::ID);
+            int box_x_ind = getInfoBoxIndex(row, NodeInfoHeader::X);
+            int box_y_ind = getInfoBoxIndex(row, NodeInfoHeader::Y);
+            int box_z_ind = getInfoBoxIndex(row, NodeInfoHeader::Z);
+            // extract this node's information
+            double node_id = (*element)->NodeIds[row];
+            double x_pos = (*element)->Positions[row][0];
+            double y_pos = (*element)->Positions[row][1];
+            double z_pos = (*element)->Positions[row][2];
+            // output information to file
+            file << node_id << "," << x_pos << "," << y_pos << "," << z_pos << ",";
+            file << "\n";
+        }
+    }
+    // throw error if we recieved a bad element
+    else {
+        throw runtime_error("Error: got nullptr when attempting to write node positions of current element");
+    }
+    // close file now that we're done with it
+    file.close();
+}

--- a/UserInterface/SourceCode/ElementBasicDisplay.cpp
+++ b/UserInterface/SourceCode/ElementBasicDisplay.cpp
@@ -20,54 +20,68 @@ int getInfoBoxIndex(int node_number, NodeInfoHeader header)
     return ((int)header) * n_nodes_per_element + node_number;
 }
 
-ElementBasicDisplay::ElementBasicDisplay()
+ElementBasicDisplay::ElementBasicDisplay(QWidget *parent) : QGridLayout(parent)
 {
-    // add the "selected item properties" label to the grid
+    // add the "selected item properties" panel header to the grid
+    // this will be the top-level parent of the QWidgets in this layout,
+    // and answers to the parent of this layout
+    selection_header = new Header(panel_header_text, parent);
     addWidget(selection_header, 0, 0, 1, 2, AL_LEFT);
 
-    // add the "element name" label to the grid
-    addWidget(element_name_label, 1, 0, 1, 1, AL_LEFT);
+    // add the element selection box
+    element_selection_box = new SelectionBox(selection_header);
+    addWidget(element_selection_box, 1, 4, 1, 1, AL_LEFT);
+    // add the element selection box's label
+    element_selection_label = new Label("Select <br> element", element_selection_box);
+    addWidget(element_selection_label, 0, 4, 1, 1, AL_LEFT);
 
+    // add node selection box
+    node_selection_box = new SelectionBox(selection_header);
+    addWidget(node_selection_box, 1, 3, 1, 1, AL_LEFT);
+    // add node selection box label
+    node_selection_label = new Label("Select <br> node:", node_selection_box);
+    addWidget(node_selection_label, 0, 3, 1, 1, AL_LEFT);
+
+    // add the "element name" label to the grid
+    element_name_label = new Header(element_name_label_text, selection_header);
+    addWidget(element_name_label, 1, 0, 1, 1, AL_LEFT);
     // add the "element name" box to the grid next to the label
+    element_name_display = new ReadOnlyBox("No element selected", element_name_label);
     addWidget(element_name_display, 1, 1, 1, 2, AL_LEFT);
 
     // add the node information headers (horz) into the grid
     for (int i=0; i<n_node_info_headers; i++) {
+        node_info_labels_horz[i] = new Header(horz_info_label_text[i], selection_header);
         addWidget(node_info_labels_horz[i], 2, i+1, 1, 1, AL_CENTRE);
     }
 
     // add the node information node numbers (vert) to the grid
     for (int i=0; i<n_nodes_per_element; i++) {
+        node_info_numbers_vert[i] = new Header(vert_node_label_text + QString::number(i, 'f', 0), selection_header);
         addWidget(node_info_numbers_vert[i], 2+(i+1), 0, 1, 1, AL_LEFT);
     }
 
     // add the node information ID and coordinate boxes
     for (int i=0; i<n_coord_boxes; i++) {
-        node_coord_boxes[i].setFixedWidth(node_coord_box_width);
+        node_coord_boxes[i] = new ReadOnlyBox(selection_header);
+        node_coord_boxes[i]->setFixedWidth(node_coord_box_width);
         // get the row and column indices in the grid for this box
         int row = 0; NodeInfoHeader col = NodeInfoHeader::ID;
         rowAndColOfBox(i, &row, &col);
         // add the widget to the grid
         // offset (row, col) by (3,1) to account for the selection boxes above,
-        // and the node #x labels to the left
-        addWidget(&node_coord_boxes[i], row+3, col+1, 1, 1, AL_LEFT);
+        // and the node # labels to the left
+        addWidget(node_coord_boxes[i], row+3, col+1, 1, 1, AL_LEFT);
     }
-
-    // add node and element display labels to the grid
-    addWidget(node_selection_label, 0, 3, 1, 1, AL_LEFT);
-    addWidget(element_selection_label, 0, 4, 1, 1, AL_LEFT);
-    // now add the corresponding boxes
-    addWidget(&node_selection_box, 1, 3, 1, 1, AL_LEFT);
-    addWidget(&element_selection_box, 1, 4, 1, 1, AL_LEFT);
 };
 
 void ElementBasicDisplay::setNodeSelectionValidator(int max_node_index, QObject *parent)
 {
-    node_selection_box.initialseValidator(max_node_index, parent);
+    node_selection_box->initialseValidator(max_node_index, parent);
 };
 void ElementBasicDisplay::setElementSelectionValidator(int max_element_index, QObject *parent)
 {
-    element_selection_box.initialseValidator(max_element_index, parent);
+    element_selection_box->initialseValidator(max_element_index, parent);
 };
 void ElementBasicDisplay::setDisplayedElementName(const QString &text) {
     element_name_display->setText(text);
@@ -75,8 +89,8 @@ void ElementBasicDisplay::setDisplayedElementName(const QString &text) {
 
 void ElementBasicDisplay::updateCoordBox(int box_number, QString text, bool set_enabled)
 {
-    node_coord_boxes[box_number].setText(text);
-    node_coord_boxes[box_number].setEnabled(set_enabled);
+    node_coord_boxes[box_number]->setText(text);
+    node_coord_boxes[box_number]->setEnabled(set_enabled);
 }
 void ElementBasicDisplay::updateCoordBox(int row, NodeInfoHeader col, QString text, bool set_enabled)
 {
@@ -118,6 +132,7 @@ void ElementBasicDisplay::updateDisplayValues(std::unique_ptr<ShapeBase> *elemen
         }
     }
 }
+
 void ElementBasicDisplay::writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element) {
     // open the file, in append mode if necessary (might have asked for node positions to be written)
     ofstream file(filename.toStdString(), std::ios_base::app);
@@ -149,4 +164,24 @@ void ElementBasicDisplay::writeNodePositions(QString filename, std::unique_ptr<S
     }
     // close file now that we're done with it
     file.close();
+}
+
+void ElementBasicDisplay::resetElementSelection(int max_element_index, QWidget *parent) {
+    // block signals whilst resetting
+    element_selection_box->blockSignals(true);
+    // reset the text in the selection box
+    setElementSelectionValidator(max_element_index, parent);
+    element_selection_box->setText("");
+    // reopen to user input
+    element_selection_box->blockSignals(false);
+}
+
+void ElementBasicDisplay::resetNodeSelection(int max_node_index, QWidget *parent) {
+    // block signals whilst resetting
+    node_selection_box->blockSignals(true);
+    // reset the text in the selection box
+    setNodeSelectionValidator(max_node_index, parent);
+    node_selection_box->setText("");
+    // reopen to user input
+    node_selection_box->blockSignals(false);
 }

--- a/UserInterface/SourceCode/ElementBasicDisplay.h
+++ b/UserInterface/SourceCode/ElementBasicDisplay.h
@@ -49,8 +49,6 @@ int getInfoBoxIndex(int node_number, NodeInfoHeader header);
  * - The "selected item properties" header
  * - The node selection and element selection boxes
  * - The printout of node information associated to a given element
- * 
- * Note: the ELEMENT SELECTION BOX (element_selection_box) will be the parent of all QWidgets in this panel
  */
 class ElementBasicDisplay : public QGridLayout
 {
@@ -59,29 +57,40 @@ public:
     /**
      * @brief Constructs the element-selection pannel.
      *
-     * @param parent Parent QWidget
      */
-    ElementBasicDisplay(QWidget *parent=nullptr);
+    ElementBasicDisplay();
 
-    Header *selection_header;  // The "Selected Item Properties" header
-    Header *element_name_label;  // The label for the content of element_name_display
+    // The "Selected Item Properties" header
+    Header *selection_header = new Header("Selected Item Properties");
+    // The label for the content of element_name_display
+    Header *element_name_label = new Header("Element name:");
     // The (horizontal) headers of the information about each node that we wish to fetch and display
-    Header *node_info_labels_horz[n_node_info_headers];
+    Header *node_info_labels_horz[n_node_info_headers] = {new Header("id"),
+                                                          new Header("x"),
+                                                          new Header("y"),
+                                                          new Header("z")};
     // The (vertical) naming convention for the nodes associated to an element
-    Header *node_info_numbers_vert[n_nodes_per_element];
+    Header *node_info_numbers_vert[n_nodes_per_element] = {new Header("Node 0"),
+                                                           new Header("Node 1"),
+                                                           new Header("Node 2"),
+                                                           new Header("Node 3"),
+                                                           new Header("Node 4"),
+                                                           new Header("Node 5")};
+    // The label for the node_selection_box
+    Label *node_selection_label = new Label("Select <br> node:");
+    // The label for the element_selection box
+    Label *element_selection_label = new Label("Select <br> element");
 
-    Label *node_selection_label; // The label for the node_selection_box
-    Label *element_selection_label; // The label for the element_selection box
-
-    ReadOnlyBox *element_name_display;  // Box to display the internal name of the selected element
+    // Box to display the internal name of the selected element
+    ReadOnlyBox *element_name_display = new ReadOnlyBox("No element selected");
     // Boxes that will display the information about the nodes associated to the selected element;
     // uses the convention box_index = col*n_nodes_per_element + n_node_info_headers
-    ReadOnlyBox *node_coord_boxes[n_coord_boxes];
+    ReadOnlyBox node_coord_boxes[n_coord_boxes];
 
     // input box for manual element selection by requesting a node that forms this element
-    SelectionBox *node_selection_box;
+    SelectionBox node_selection_box;
     // input box for manual element selection by element ID
-    SelectionBox *element_selection_box;
+    SelectionBox element_selection_box;
 
     /**
      * @brief Sets (or resets) the validator object for the node_selection_box
@@ -138,28 +147,9 @@ public slots:
      * @param element (Pointer to) the element whose node positions should be written
      */
     void writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element);
-    /**
-     * @brief Reset the validator attached to the element selection box
-     * 
-     * @param max_element_index Maximum element ID of the simulation
-     * @param parent Parent Widget
-     */
-    void resetElementSelection(int max_element_index, QWidget *parent=nullptr);
-    /**
-     * @brief Reset the validator attached to the node selection box
-     * 
-     * @param max_node_index Maximum node ID of the simulation
-     * @param parent Parent Widget
-     */
-    void resetNodeSelection(int max_node_index, QWidget *parent=nullptr);
 
 private:
-    int node_coord_box_width = 70; // default width for infoboxes displaying node coords, etc
-
-    const QString panel_header_text = "Selected Item Properties"; // header for the panel
-    const QString element_name_label_text = "Element Name:"; // label for element name display
-    const QStringList horz_info_label_text = {"ID, x, y, z"}; // header labels detailing the content of the information boxes
-    const QString vert_node_label_text = "Node "; // how to label the node rows
+    int node_coord_box_width = 70;      // default width for infoboxes displaying node coords, etc
 };
 
 #endif

--- a/UserInterface/SourceCode/ElementBasicDisplay.h
+++ b/UserInterface/SourceCode/ElementBasicDisplay.h
@@ -140,6 +140,13 @@ public slots:
      * @param element The new element, whose information should be displayed. nullptr is interpretted as deselection.
      */
     void updateDisplayValues(std::unique_ptr<ShapeBase> *element);
+    /**
+     * @brief Writes the currently-displayed node positions to the file provided
+     * 
+     * @param filename File to APPEND node positions to
+     * @param element (Pointer to) the element whose node positions should be written
+     */
+    void writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element);
 
 private:
     int node_coord_box_width = 70;      // default width for infoboxes displaying node coords, etc

--- a/UserInterface/SourceCode/ElementBasicDisplay.h
+++ b/UserInterface/SourceCode/ElementBasicDisplay.h
@@ -49,6 +49,8 @@ int getInfoBoxIndex(int node_number, NodeInfoHeader header);
  * - The "selected item properties" header
  * - The node selection and element selection boxes
  * - The printout of node information associated to a given element
+ * 
+ * Note: the ELEMENT SELECTION BOX (element_selection_box) will be the parent of all QWidgets in this panel
  */
 class ElementBasicDisplay : public QGridLayout
 {
@@ -57,40 +59,29 @@ public:
     /**
      * @brief Constructs the element-selection pannel.
      *
+     * @param parent Parent QWidget
      */
-    ElementBasicDisplay();
+    ElementBasicDisplay(QWidget *parent=nullptr);
 
-    // The "Selected Item Properties" header
-    Header *selection_header = new Header("Selected Item Properties");
-    // The label for the content of element_name_display
-    Header *element_name_label = new Header("Element name:");
+    Header *selection_header;  // The "Selected Item Properties" header
+    Header *element_name_label;  // The label for the content of element_name_display
     // The (horizontal) headers of the information about each node that we wish to fetch and display
-    Header *node_info_labels_horz[n_node_info_headers] = {new Header("id"),
-                                                          new Header("x"),
-                                                          new Header("y"),
-                                                          new Header("z")};
+    Header *node_info_labels_horz[n_node_info_headers];
     // The (vertical) naming convention for the nodes associated to an element
-    Header *node_info_numbers_vert[n_nodes_per_element] = {new Header("Node 0"),
-                                                           new Header("Node 1"),
-                                                           new Header("Node 2"),
-                                                           new Header("Node 3"),
-                                                           new Header("Node 4"),
-                                                           new Header("Node 5")};
-    // The label for the node_selection_box
-    Label *node_selection_label = new Label("Select <br> node:");
-    // The label for the element_selection box
-    Label *element_selection_label = new Label("Select <br> element");
+    Header *node_info_numbers_vert[n_nodes_per_element];
 
-    // Box to display the internal name of the selected element
-    ReadOnlyBox *element_name_display = new ReadOnlyBox("No element selected");
+    Label *node_selection_label; // The label for the node_selection_box
+    Label *element_selection_label; // The label for the element_selection box
+
+    ReadOnlyBox *element_name_display;  // Box to display the internal name of the selected element
     // Boxes that will display the information about the nodes associated to the selected element;
     // uses the convention box_index = col*n_nodes_per_element + n_node_info_headers
-    ReadOnlyBox node_coord_boxes[n_coord_boxes];
+    ReadOnlyBox *node_coord_boxes[n_coord_boxes];
 
     // input box for manual element selection by requesting a node that forms this element
-    SelectionBox node_selection_box;
+    SelectionBox *node_selection_box;
     // input box for manual element selection by element ID
-    SelectionBox element_selection_box;
+    SelectionBox *element_selection_box;
 
     /**
      * @brief Sets (or resets) the validator object for the node_selection_box
@@ -147,9 +138,28 @@ public slots:
      * @param element (Pointer to) the element whose node positions should be written
      */
     void writeNodePositions(QString filename, std::unique_ptr<ShapeBase> *element);
+    /**
+     * @brief Reset the validator attached to the element selection box
+     * 
+     * @param max_element_index Maximum element ID of the simulation
+     * @param parent Parent Widget
+     */
+    void resetElementSelection(int max_element_index, QWidget *parent=nullptr);
+    /**
+     * @brief Reset the validator attached to the node selection box
+     * 
+     * @param max_node_index Maximum node ID of the simulation
+     * @param parent Parent Widget
+     */
+    void resetNodeSelection(int max_node_index, QWidget *parent=nullptr);
 
 private:
-    int node_coord_box_width = 70;      // default width for infoboxes displaying node coords, etc
+    int node_coord_box_width = 70; // default width for infoboxes displaying node coords, etc
+
+    const QString panel_header_text = "Selected Item Properties"; // header for the panel
+    const QString element_name_label_text = "Element Name:"; // label for element name display
+    const QStringList horz_info_label_text = {"ID, x, y, z"}; // header labels detailing the content of the information boxes
+    const QString vert_node_label_text = "Node "; // how to label the node rows
 };
 
 #endif

--- a/UserInterface/SourceCode/ElementPropertySelection.cpp
+++ b/UserInterface/SourceCode/ElementPropertySelection.cpp
@@ -3,9 +3,11 @@
 
 ElementPropertySelection::ElementPropertySelection() {
     // add the pannel header, align left
+    pannel_header = new Header("Display element property:");
     addWidget(pannel_header, 0, 0, 1, 2, AL_LEFT);
 
     // add the dropdown menu, align centre
+    selection_dropdown = new DropdownMenu(element_property_options);
     addWidget(selection_dropdown, 0, 2, 1, 2, AL_CENTRE);
 
     // add the widget that will display the selected element property
@@ -13,6 +15,7 @@ ElementPropertySelection::ElementPropertySelection() {
     addWidget(&display_box, 1, 1, max_disp_rows-1, n_cols-1, AL_CENTRE);
 
     // add the save button
+    save_element_properties = new Button("Export\n properties of\n selected\n element");
     addWidget(save_element_properties, 1, 0, max_disp_rows-1, 1, AL_CENTRE);
 
     // connect: choosing a different property should change the property display
@@ -21,6 +24,12 @@ ElementPropertySelection::ElementPropertySelection() {
     // connect: clicking the save button triggers the save action
     connect(save_element_properties, SIGNAL(clicked()),
             this, SLOT(clickedSaveElementProperties()));
+
+    // add the toggle for exporting node positions
+    node_positions_on_export = new CheckBox("Export node positions associated to elements", false);
+    addWidget(node_positions_on_export, max_disp_rows+1, 0, 1, n_cols, AL_LEFT);
+    // box is checkable if and only if selection is available
+    connect(this, SIGNAL(dropdownIsNowEnabled(bool)), node_positions_on_export, SLOT(setEnabled(bool)));
 }
 
 void ElementPropertySelection::updatePropertyValues(std::unique_ptr<ShapeBase> *element)
@@ -50,6 +59,11 @@ void ElementPropertySelection::clickedSaveElementProperties() {
         std::remove(saveFileName.toStdString().c_str());
         // write the element properties to the file
         element_property_display.writeToFile(saveFileName);
+        // if the checkbox is ticked, also write the node properties to this file
+        if (node_positions_on_export->isChecked()) {
+            std::unique_ptr<ShapeBase> *element = element_property_display.getCurrentElement();
+            emit writeNodePositionsToFile(saveFileName, element);
+        }
     }
 }
 

--- a/UserInterface/SourceCode/ElementPropertySelection.h
+++ b/UserInterface/SourceCode/ElementPropertySelection.h
@@ -13,20 +13,14 @@ class ElementPropertySelection : public QGridLayout
 public:
     ElementPropertySelection();
 
-    // header for pannel
-    Header *pannel_header = new Header("Display element property:");
+    Header *pannel_header;  // header for pannel
+    DropdownMenu *selection_dropdown;  // selection box for the element property to display
+    PropertyDisplayLayout element_property_display;  // display for the currently selected element property
+    QGroupBox display_box; // box wrapping the property display
+    Button *save_element_properties; // box that allows the user to request the element properties be saved
+    CheckBox *node_positions_on_export;  // checkbox that toggles the export of node positions with the element properties
 
-    // selection box for the element property to display
-    DropdownMenu *selection_dropdown = new DropdownMenu(element_property_options);
-
-    // the box that displays the currently selected element property
-    PropertyDisplayLayout element_property_display;
-    QGroupBox display_box;
-
-    // the box that allows the user to request the element properties be saved
-    Button *save_element_properties = new Button("Export\n properties of\n selected\n element");
-
-public slots:
+   public slots:
     /**
      * @brief Updates the values stored in the element_property_display to match those of the new element
      *
@@ -58,6 +52,13 @@ signals:
      * @param enabled Whether the dropdown has been enabled (true) or disabled (false)
      */
     void dropdownIsNowEnabled(bool enabled);
+    /**
+     * @brief Emitted whenever element properties are exported, and the user has requested this include the associated node properties
+     * 
+     * @param filename File to append the node information to
+     * @param element (Pointer to) element whose node-information should be written
+     */
+    void writeNodePositionsToFile(QString filename, std::unique_ptr<ShapeBase> *element);
 
 private:
     int n_cols = 5;         // number of columns in the grid layout

--- a/UserInterface/SourceCode/GUIBuildingBlocks.cpp
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.cpp
@@ -8,13 +8,13 @@ Label::Label(string text) : QLabel(text.c_str()) {
     setFont(DEF_FONT);
 }
 
-Header::Header() : QLabel() {
+Header::Header(QWidget *parent) : QLabel(parent) {
     setFont(DEF_HEADER_FONT);
 }
-Header::Header(string text) : QLabel(text.c_str()) {
+Header::Header(string text, QWidget *parent) : QLabel(text.c_str(), parent) {
     setFont(DEF_HEADER_FONT);
 }
-Header::Header(QString &text) : QLabel(text) {
+Header::Header(QString &text, QWidget *parent) : QLabel(text, parent) {
     setFont(DEF_HEADER_FONT);
 }
 
@@ -198,4 +198,17 @@ void SingleBoxLayout::setDisplayValue(double value) {
 }
 void SingleBoxLayout::clearValue() {
     display_box->setText(default_text);
+}
+
+#include<iostream>
+CheckBox::CheckBox() : QCheckBox() {
+    setFont(DEF_FONT);
+    setCheckable(true);
+    setChecked(false);
+}
+CheckBox::CheckBox(const QString &text, bool start_enabled) : QCheckBox(text) {
+    setFont(DEF_FONT);
+    setCheckable(true);
+    setChecked(false);
+    setEnabled(start_enabled);
 }

--- a/UserInterface/SourceCode/GUIBuildingBlocks.cpp
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.cpp
@@ -1,10 +1,16 @@
 # include "GUIBuildingBlocks.h"
 using namespace std;
 
-Label::Label() : QLabel() {
+Label::Label(QWidget *parent) : QLabel(parent) {
     setFont(DEF_FONT);
 }
-Label::Label(string text) : QLabel(text.c_str()) {
+Label::Label(string text, QWidget *parent) : QLabel(text.c_str(), parent) {
+    setFont(DEF_FONT);
+}
+Label::Label(const QString &text, QWidget *parent) : QLabel(text, parent) {
+    setFont(DEF_FONT);
+}
+Label::Label(const char *text, QWidget *parent) : QLabel(text, parent) {
     setFont(DEF_FONT);
 }
 
@@ -14,11 +20,14 @@ Header::Header(QWidget *parent) : QLabel(parent) {
 Header::Header(string text, QWidget *parent) : QLabel(text.c_str(), parent) {
     setFont(DEF_HEADER_FONT);
 }
-Header::Header(QString &text, QWidget *parent) : QLabel(text, parent) {
+Header::Header(const QString &text, QWidget *parent) : QLabel(text, parent) {
+    setFont(DEF_HEADER_FONT);
+}
+Header::Header(const char *text, QWidget *parent) : QLabel(text, parent) {
     setFont(DEF_HEADER_FONT);
 }
 
-ReadOnlyBox::ReadOnlyBox() : QLineEdit() {
+ReadOnlyBox::ReadOnlyBox(QWidget *parent) : QLineEdit(parent) {
     // text that fills the box when nothing is provided
     setPlaceholderText(default_text);
     // make read-only
@@ -26,7 +35,7 @@ ReadOnlyBox::ReadOnlyBox() : QLineEdit() {
     // use our default font
     setFont(DEF_FONT);
 }
-ReadOnlyBox::ReadOnlyBox(string placeholder_text) : QLineEdit() {
+ReadOnlyBox::ReadOnlyBox(string placeholder_text, QWidget *parent) : QLineEdit(parent) {
     // text that fills the box when nothing is provided
     setPlaceholderText(placeholder_text.c_str());
     // make read-only
@@ -35,7 +44,7 @@ ReadOnlyBox::ReadOnlyBox(string placeholder_text) : QLineEdit() {
     setFont(DEF_FONT);
 }
 
-SelectionBox::SelectionBox() : QLineEdit() {
+SelectionBox::SelectionBox(QWidget *parent) : QLineEdit(parent) {
     // text that fills the box when nothing is provided
     setPlaceholderText("-");
     // use our default font
@@ -45,7 +54,7 @@ SelectionBox::SelectionBox() : QLineEdit() {
     // box should be of fixed width
     setFixedWidth(def_fixed_box_width);
 }
-SelectionBox::SelectionBox(string placeholder_text) : QLineEdit() {
+SelectionBox::SelectionBox(string placeholder_text, QWidget *parent) : QLineEdit(parent) {
     // text that fills the box when nothing is provided
     setPlaceholderText(placeholder_text.c_str());
     // use our default font

--- a/UserInterface/SourceCode/GUIBuildingBlocks.cpp
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.cpp
@@ -1,16 +1,10 @@
 # include "GUIBuildingBlocks.h"
 using namespace std;
 
-Label::Label(QWidget *parent) : QLabel(parent) {
+Label::Label() : QLabel() {
     setFont(DEF_FONT);
 }
-Label::Label(string text, QWidget *parent) : QLabel(text.c_str(), parent) {
-    setFont(DEF_FONT);
-}
-Label::Label(const QString &text, QWidget *parent) : QLabel(text, parent) {
-    setFont(DEF_FONT);
-}
-Label::Label(const char *text, QWidget *parent) : QLabel(text, parent) {
+Label::Label(string text) : QLabel(text.c_str()) {
     setFont(DEF_FONT);
 }
 
@@ -20,14 +14,11 @@ Header::Header(QWidget *parent) : QLabel(parent) {
 Header::Header(string text, QWidget *parent) : QLabel(text.c_str(), parent) {
     setFont(DEF_HEADER_FONT);
 }
-Header::Header(const QString &text, QWidget *parent) : QLabel(text, parent) {
-    setFont(DEF_HEADER_FONT);
-}
-Header::Header(const char *text, QWidget *parent) : QLabel(text, parent) {
+Header::Header(QString &text, QWidget *parent) : QLabel(text, parent) {
     setFont(DEF_HEADER_FONT);
 }
 
-ReadOnlyBox::ReadOnlyBox(QWidget *parent) : QLineEdit(parent) {
+ReadOnlyBox::ReadOnlyBox() : QLineEdit() {
     // text that fills the box when nothing is provided
     setPlaceholderText(default_text);
     // make read-only
@@ -35,7 +26,7 @@ ReadOnlyBox::ReadOnlyBox(QWidget *parent) : QLineEdit(parent) {
     // use our default font
     setFont(DEF_FONT);
 }
-ReadOnlyBox::ReadOnlyBox(string placeholder_text, QWidget *parent) : QLineEdit(parent) {
+ReadOnlyBox::ReadOnlyBox(string placeholder_text) : QLineEdit() {
     // text that fills the box when nothing is provided
     setPlaceholderText(placeholder_text.c_str());
     // make read-only
@@ -44,7 +35,7 @@ ReadOnlyBox::ReadOnlyBox(string placeholder_text, QWidget *parent) : QLineEdit(p
     setFont(DEF_FONT);
 }
 
-SelectionBox::SelectionBox(QWidget *parent) : QLineEdit(parent) {
+SelectionBox::SelectionBox() : QLineEdit() {
     // text that fills the box when nothing is provided
     setPlaceholderText("-");
     // use our default font
@@ -54,7 +45,7 @@ SelectionBox::SelectionBox(QWidget *parent) : QLineEdit(parent) {
     // box should be of fixed width
     setFixedWidth(def_fixed_box_width);
 }
-SelectionBox::SelectionBox(string placeholder_text, QWidget *parent) : QLineEdit(parent) {
+SelectionBox::SelectionBox(string placeholder_text) : QLineEdit() {
     // text that fills the box when nothing is provided
     setPlaceholderText(placeholder_text.c_str());
     // use our default font

--- a/UserInterface/SourceCode/GUIBuildingBlocks.h
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.h
@@ -27,13 +27,16 @@ class Label : public QLabel
 {
     Q_OBJECT
 public:
-    Label();
+    Label(QWidget *parent=nullptr);
     /**
      * @brief Construct a new Label object
      *
      * @param text Text of this label
+     * @param parent Parent QWidget object
      */
-    Label(std::string text);
+    Label(std::string text, QWidget *parent=nullptr);
+    Label(const QString &text, QWidget *parent=nullptr);
+    Label(const char *text, QWidget *parent=nullptr);
 };
 
 /**
@@ -53,7 +56,8 @@ public:
      * @param parent Parent QWidget
      */
     Header(std::string text, QWidget *parent=nullptr);
-    Header(QString &text, QWidget *parent=nullptr);
+    Header(const QString &text, QWidget *parent=nullptr);
+    Header(const char *text, QWidget *parent=nullptr);
 };
 
 /**
@@ -65,13 +69,14 @@ class ReadOnlyBox : public QLineEdit
 {
     Q_OBJECT
 public:
-    ReadOnlyBox();
+    ReadOnlyBox(QWidget *parent=nullptr);
     /**
      * @brief Construct a new Read Only Box object
      *
      * @param placeholder_text Text to display when no input has been provided to the box
+     * @param parent Parent QWidget
      */
-    ReadOnlyBox(std::string placeholder_text);
+    ReadOnlyBox(std::string placeholder_text, QWidget *parent=nullptr);
     
 private:
     // default fixed size for infoboxes
@@ -89,13 +94,13 @@ class SelectionBox : public QLineEdit
 {
     Q_OBJECT
 public:
-    SelectionBox();
+    SelectionBox(QWidget *parent=nullptr);
     /**
      * @brief Construct a new Selection Box object
      *
      * @param placeholder_text Text to display when no input has been provided to the box
      */
-    SelectionBox(std::string placeholder_text);
+    SelectionBox(std::string placeholder_text, QWidget *parent=nullptr);
 
     /**
      * @brief Setup the selection validator for this box.

--- a/UserInterface/SourceCode/GUIBuildingBlocks.h
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.h
@@ -45,15 +45,15 @@ class Header : public QLabel
 {
     Q_OBJECT
 public:
-    Header();
+    Header(QWidget *parent=nullptr);
     /**
      * @brief Construct a new Header object
      *
      * @param text Text of this header
      * @param parent Parent QWidget
      */
-    Header(std::string text);
-    Header(QString &text);
+    Header(std::string text, QWidget *parent=nullptr);
+    Header(QString &text, QWidget *parent=nullptr);
 };
 
 /**
@@ -304,6 +304,19 @@ private:
     QString default_text = "-"; // default displayed text
 
     ReadOnlyBox *display_box; // box that displays the single value
+};
+
+class CheckBox : public QCheckBox {
+    Q_OBJECT
+public:
+    CheckBox();
+    /**
+     * @brief Construct a new Check Box object, with the text provided
+     * 
+     * @param text Text to label the checkbox with
+     * @param start_enabled Whether to initalise the checkbox enabled (true) or disabled (false)
+     */
+    CheckBox(const QString &text, bool start_enabled=true);
 };
 
 # endif

--- a/UserInterface/SourceCode/GUIBuildingBlocks.h
+++ b/UserInterface/SourceCode/GUIBuildingBlocks.h
@@ -27,16 +27,13 @@ class Label : public QLabel
 {
     Q_OBJECT
 public:
-    Label(QWidget *parent=nullptr);
+    Label();
     /**
      * @brief Construct a new Label object
      *
      * @param text Text of this label
-     * @param parent Parent QWidget object
      */
-    Label(std::string text, QWidget *parent=nullptr);
-    Label(const QString &text, QWidget *parent=nullptr);
-    Label(const char *text, QWidget *parent=nullptr);
+    Label(std::string text);
 };
 
 /**
@@ -56,8 +53,7 @@ public:
      * @param parent Parent QWidget
      */
     Header(std::string text, QWidget *parent=nullptr);
-    Header(const QString &text, QWidget *parent=nullptr);
-    Header(const char *text, QWidget *parent=nullptr);
+    Header(QString &text, QWidget *parent=nullptr);
 };
 
 /**
@@ -69,14 +65,13 @@ class ReadOnlyBox : public QLineEdit
 {
     Q_OBJECT
 public:
-    ReadOnlyBox(QWidget *parent=nullptr);
+    ReadOnlyBox();
     /**
      * @brief Construct a new Read Only Box object
      *
      * @param placeholder_text Text to display when no input has been provided to the box
-     * @param parent Parent QWidget
      */
-    ReadOnlyBox(std::string placeholder_text, QWidget *parent=nullptr);
+    ReadOnlyBox(std::string placeholder_text);
     
 private:
     // default fixed size for infoboxes
@@ -94,13 +89,13 @@ class SelectionBox : public QLineEdit
 {
     Q_OBJECT
 public:
-    SelectionBox(QWidget *parent=nullptr);
+    SelectionBox();
     /**
      * @brief Construct a new Selection Box object
      *
      * @param placeholder_text Text to display when no input has been provided to the box
      */
-    SelectionBox(std::string placeholder_text, QWidget *parent=nullptr);
+    SelectionBox(std::string placeholder_text);
 
     /**
      * @brief Setup the selection validator for this box.

--- a/UserInterface/SourceCode/MainWindow.cpp
+++ b/UserInterface/SourceCode/MainWindow.cpp
@@ -77,13 +77,13 @@ void MainWindow::generateControlPanel(){
 	ControlPanelMainHBox->setSpacing(2);
 
 	// perpare the basic element info display using the default constructor
-	ElementProps = new ElementBasicDisplay;
+	ElementProps = new ElementBasicDisplay();
 	// initialise the validators for the node and element selection boxes
 	ElementProps->setNodeSelectionValidator(Sim01->Nodes.size() - 1, this);
 	ElementProps->setElementSelectionValidator(Sim01->Elements.size() - 1, this);
 	// create connections for the node and element selection boxes
-	connect(&(ElementProps->node_selection_box), SIGNAL(textChanged(const QString &)), this, SLOT(manualNodeSelection(const QString &)));
-	connect(&(ElementProps->element_selection_box), SIGNAL(textChanged(const QString &)), this, SLOT(manualElementSelection(const QString &)));
+	connect(ElementProps->node_selection_box, SIGNAL(textChanged(const QString &)), this, SLOT(manualNodeSelection(const QString &)));
+	connect(ElementProps->element_selection_box, SIGNAL(textChanged(const QString &)), this, SLOT(manualElementSelection(const QString &)));
 	// connect basic element display to update when lookingAtNewElement signal is sent out
 	connect(this, SIGNAL(lookingAtNewElement(std::unique_ptr<ShapeBase> *)), ElementProps, SLOT(updateDisplayValues(std::unique_ptr<ShapeBase> *)));
 	// connect to the main display
@@ -662,23 +662,11 @@ void MainWindow::manualElementSelection(const QString &newValue){
 void MainWindow::ManualElementSelectionReset(){
 	MainGLWidget->ManualNodeSelection = false;
 	MainGLWidget->ManualSelectedNodeId = -100;
-	// block signals whilst resetting
-	ElementProps->element_selection_box.blockSignals(true);
-	// reset the text in the selection box
-	ElementProps->setElementSelectionValidator(Sim01->Elements.size()-1, this);
-	ElementProps->element_selection_box.setText("");
-	// reopen to user input
-	ElementProps->element_selection_box.blockSignals(false);
+	ElementProps->resetElementSelection(Sim01->Elements.size()-1);
 }
 
 void MainWindow::ManualNodeSelectionReset(){
-	// block signals whilst resetting
-	ElementProps->node_selection_box.blockSignals(true);
-	// reset the text in the selection box
-	ElementProps->setNodeSelectionValidator(Sim01->Nodes.size()-1, this);
-	ElementProps->node_selection_box.setText("");
-	// reopen to user input
-	ElementProps->node_selection_box.blockSignals(false);
+	ElementProps->resetNodeSelection(Sim01->Nodes.size()-1, this);
 }
 
 void MainWindow::testAdhesionsAndCurveConstruction(){

--- a/UserInterface/SourceCode/MainWindow.cpp
+++ b/UserInterface/SourceCode/MainWindow.cpp
@@ -77,13 +77,13 @@ void MainWindow::generateControlPanel(){
 	ControlPanelMainHBox->setSpacing(2);
 
 	// perpare the basic element info display using the default constructor
-	ElementProps = new ElementBasicDisplay();
+	ElementProps = new ElementBasicDisplay;
 	// initialise the validators for the node and element selection boxes
 	ElementProps->setNodeSelectionValidator(Sim01->Nodes.size() - 1, this);
 	ElementProps->setElementSelectionValidator(Sim01->Elements.size() - 1, this);
 	// create connections for the node and element selection boxes
-	connect(ElementProps->node_selection_box, SIGNAL(textChanged(const QString &)), this, SLOT(manualNodeSelection(const QString &)));
-	connect(ElementProps->element_selection_box, SIGNAL(textChanged(const QString &)), this, SLOT(manualElementSelection(const QString &)));
+	connect(&(ElementProps->node_selection_box), SIGNAL(textChanged(const QString &)), this, SLOT(manualNodeSelection(const QString &)));
+	connect(&(ElementProps->element_selection_box), SIGNAL(textChanged(const QString &)), this, SLOT(manualElementSelection(const QString &)));
 	// connect basic element display to update when lookingAtNewElement signal is sent out
 	connect(this, SIGNAL(lookingAtNewElement(std::unique_ptr<ShapeBase> *)), ElementProps, SLOT(updateDisplayValues(std::unique_ptr<ShapeBase> *)));
 	// connect to the main display
@@ -662,11 +662,23 @@ void MainWindow::manualElementSelection(const QString &newValue){
 void MainWindow::ManualElementSelectionReset(){
 	MainGLWidget->ManualNodeSelection = false;
 	MainGLWidget->ManualSelectedNodeId = -100;
-	ElementProps->resetElementSelection(Sim01->Elements.size()-1);
+	// block signals whilst resetting
+	ElementProps->element_selection_box.blockSignals(true);
+	// reset the text in the selection box
+	ElementProps->setElementSelectionValidator(Sim01->Elements.size()-1, this);
+	ElementProps->element_selection_box.setText("");
+	// reopen to user input
+	ElementProps->element_selection_box.blockSignals(false);
 }
 
 void MainWindow::ManualNodeSelectionReset(){
-	ElementProps->resetNodeSelection(Sim01->Nodes.size()-1, this);
+	// block signals whilst resetting
+	ElementProps->node_selection_box.blockSignals(true);
+	// reset the text in the selection box
+	ElementProps->setNodeSelectionValidator(Sim01->Nodes.size()-1, this);
+	ElementProps->node_selection_box.setText("");
+	// reopen to user input
+	ElementProps->node_selection_box.blockSignals(false);
 }
 
 void MainWindow::testAdhesionsAndCurveConstruction(){

--- a/UserInterface/SourceCode/MainWindow.cpp
+++ b/UserInterface/SourceCode/MainWindow.cpp
@@ -96,9 +96,12 @@ void MainWindow::generateControlPanel(){
 	// connect to the main display
 	ControlPanelMainHBox->addLayout(PropertySelection,Qt::AlignCenter);
 
-	//Generating project display options panel:
+	// connect the export selected element properties button to the node information display
+    connect(PropertySelection, SIGNAL(writeNodePositionsToFile(QString, std::unique_ptr<ShapeBase> *)), ElementProps, SLOT(writeNodePositions(QString, std::unique_ptr<ShapeBase> *)));
+
+	// Generating project display options panel:
 	QGridLayout *ProjectDisplayOptionsGrid = new QGridLayout;
-	setUpProjectDisplayOptionGrid(ProjectDisplayOptionsGrid);
+    setUpProjectDisplayOptionGrid(ProjectDisplayOptionsGrid);
 	ControlPanelMainHBox->addLayout(ProjectDisplayOptionsGrid,Qt::AlignTop);
 
 	//Generating view options Panel:

--- a/UserInterface/SourceCode/PropertyDisplayLayout.cpp
+++ b/UserInterface/SourceCode/PropertyDisplayLayout.cpp
@@ -300,4 +300,10 @@ void PropertyDisplayLayout::writeToFile(const QString &filename, bool write_head
         }
         file << "\n";
     }
+    // we should close the file now that we're done with it
+    file.close();
+}
+
+std::unique_ptr<ShapeBase> *PropertyDisplayLayout::getCurrentElement() {
+    return current_element;
 }

--- a/UserInterface/SourceCode/PropertyDisplayLayout.h
+++ b/UserInterface/SourceCode/PropertyDisplayLayout.h
@@ -61,6 +61,11 @@ public slots:
      * @param write_headers Whether to break data up by writing section headers
      */
     void writeToFile(const QString &filename, bool write_headers=true);
+    /**
+     * @brief Get (the pointer to) the current element
+     * 
+     */
+    std::unique_ptr<ShapeBase> *getCurrentElement();
 
 signals:
     /**


### PR DESCRIPTION
## Summary

Adds the option to export the coordinates of nodes associated to the selected element, when exporting the physical/strain properties of the selected node in the GUI.

## Testing

Export was performed with the "node export" option toggled on and off, for a selection of element. For each element output, the output files differed only in the node coordinates being appended to one of the exports and not the other.

## Related Issues

* Depends on #44
* Closes #50 
